### PR TITLE
feat: enable git signs in telescope preview windows

### DIFF
--- a/lua/peinan/plugins/telescope.lua
+++ b/lua/peinan/plugins/telescope.lua
@@ -174,15 +174,29 @@ TS.setup({
 vim.api.nvim_create_autocmd("User", {
     pattern = "TelescopePreviewerLoaded",
     callback = function(args)
-        vim.opt_local.number = true
-        -- Attach gitsigns to preview buffer if it's a file
-        if args.data and args.data.bufnr then
-            local bufnr = args.data.bufnr
-            local bufname = vim.api.nvim_buf_get_name(bufnr)
-            if bufname ~= "" and vim.fn.filereadable(bufname) == 1 then
-                require("gitsigns").attach(bufnr)
+        local bufnr = args.buf
+        local bufname = args.data and args.data.bufname or nil
+
+        vim.schedule(function()
+            if not bufnr or not vim.api.nvim_buf_is_valid(bufnr) then
+                return
             end
-        end
+
+            vim.api.nvim_buf_call(bufnr, function()
+                vim.opt_local.number = true
+                vim.opt_local.signcolumn = "yes"
+            end)
+
+            if bufname and bufname ~= "" and vim.fn.filereadable(bufname) == 1 then
+                pcall(function()
+                    vim.api.nvim_buf_set_name(bufnr, bufname)
+                    local original_buftype = vim.bo[bufnr].buftype
+                    vim.bo[bufnr].buftype = ""
+                    require("gitsigns").attach(bufnr)
+                    vim.bo[bufnr].buftype = original_buftype
+                end)
+            end
+        end)
     end,
 })
 


### PR DESCRIPTION
This PR implements git signs in telescope preview windows.

## Changes
- Modified `lua/peinan/plugins/telescope.lua` to attach gitsigns to preview buffers
- Extended the TelescopePreviewerLoaded autocmd to enable git change indicators

## Behavior
When telescope loads a file preview, git signs are now displayed in the signcolumn, showing additions, modifications, and deletions.

Fixes #4

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds git change indicators to Telescope previews.
> 
> - Extends `TelescopePreviewerLoaded` autocmd to receive `args`, validate `bufnr`, and run in a scheduled context
> - Sets preview buffer options: `number` and `signcolumn = "yes"`
> - For readable files, sets buffer name and temporarily clears `buftype` to safely `require("gitsigns").attach(bufnr)`, then restores it
> - Changes localized to `lua/peinan/plugins/telescope.lua`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 574d80db7349db35408e3fc532501a4cec032637. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->