### PR TITLE
feat: add dynamic window width adjustment for mini.files directory listings

### DIFF
--- a/lua/peinan/plugins/mini-files.lua
+++ b/lua/peinan/plugins/mini-files.lua
@@ -25,10 +25,39 @@ MiniFiles.setup({
 vim.api.nvim_create_autocmd("User", {
     pattern = "MiniFilesWindowUpdate",
     callback = function(args)
-        vim.api.nvim_win_set_config(args.data.win_id, {
+        local win_id = args.data.win_id
+        local buf_id = vim.api.nvim_win_get_buf(win_id)
+
+        -- Calculate appropriate width based on buffer content
+        local width = 80 -- default for file previews
+        local lines = vim.api.nvim_buf_get_lines(buf_id, 0, -1, false)
+
+        -- Check if this is likely a directory listing (short lines, likely just filenames)
+        local max_line_length = 0
+        local is_likely_dir = true
+        for _, line in ipairs(lines) do
+            local line_length = vim.fn.strdisplaywidth(line)
+            max_line_length = math.max(max_line_length, line_length)
+            -- If we find a line longer than 100 chars, it's likely a file content
+            if line_length > 100 then
+                is_likely_dir = false
+                break
+            end
+        end
+
+        -- For directory listings, use a narrower width that fits the content
+        if is_likely_dir and max_line_length > 0 then
+            -- Add some padding (10 chars) to the longest line, but cap at 50
+            width = math.min(max_line_length + 10, 50)
+            -- Ensure minimum width of 30
+            width = math.max(width, 30)
+        end
+
+        vim.api.nvim_win_set_config(win_id, {
             border = { "╭", "─", "╮", "│", "╯", "─", "╰", "│" },
+            width = width,
         })
-        vim.wo[args.data.win_id].winhighlight =
+        vim.wo[win_id].winhighlight =
             "NormalFloat:MiniFilesNormal,FloatBorder:MiniFilesBorder,FloatTitle:MiniFilesTitle,CursorLine:MiniFilesCursorLine"
     end,
 })


### PR DESCRIPTION
Fixes #15

Adds dynamic window width adjustment to mini.files that distinguishes between directory listings and file previews.

**Changes:**
- Directory listings now use narrower width (30-50 chars) based on longest filename
- File previews maintain the 80-character width
- Automatic detection based on content analysis

Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit f58cde29567ad64a88b573ba279877685a683114. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->